### PR TITLE
added new endpoint and updated hash function for graphs

### DIFF
--- a/app/DynamicGraphs/GraphGenerator.hs
+++ b/app/DynamicGraphs/GraphGenerator.hs
@@ -4,6 +4,7 @@ module DynamicGraphs.GraphGenerator
   ( sampleGraph
   , coursesToPrereqGraph
   , coursesToPrereqGraphExcluding
+  , emptyGraph
   )
   where
 
@@ -157,6 +158,9 @@ buildGraph statements = DotGraph {
         GA edgeAttrs
         ] ++ statements
     }
+
+emptyGraph :: DotGraph Text
+emptyGraph = buildGraph []
 
 -- | Means the layout of the full graph is from left to right.
 graphAttrs :: GlobalAttributes

--- a/app/DynamicGraphs/WriteRunDot.hs
+++ b/app/DynamicGraphs/WriteRunDot.hs
@@ -5,7 +5,7 @@ import Control.Monad.IO.Class (liftIO)
 import Data.GraphViz hiding (Str)
 import System.FilePath (FilePath, combine, normalise)
 import System.Directory (createDirectoryIfMissing)
-import DynamicGraphs.GraphGenerator (coursesToPrereqGraph, coursesToPrereqGraphExcluding)
+import DynamicGraphs.GraphGenerator (coursesToPrereqGraph, coursesToPrereqGraphExcluding, emptyGraph)
 import Happstack.Server (ServerPart, lookBS)
 import Happstack.Server.SimpleHTTP (Response)
 import qualified Data.Text as T
@@ -16,6 +16,7 @@ import Data.Hash.MD5 (Str(Str), md5s)
 import Database.CourseQueries (getGraph)
 import Data.Aeson (decode)
 import Data.Maybe (fromMaybe)
+import Data.List (sort)
 
 doDots :: PrintDotRepr dg n => [(FilePath, dg n)] -> IO ()
 doDots cases = do
@@ -30,16 +31,16 @@ generatePrereqsForCourses (output, courses) = do
     ++ show courses
     ++ " in graphs/gen"
 
-findPrereqsResponse :: ServerPart Response
-findPrereqsResponse = do
+findAndSavePrereqsResponse :: ServerPart Response
+findAndSavePrereqsResponse = do
     takenStr <- lookBS "taken"
     coursesStr <- lookBS "courses"
     let taken = fromMaybe [] $ decode takenStr
         courses = fromMaybe [] $ decode coursesStr
-    liftIO $ generatePrereqResponse taken courses
+    liftIO $ generateAndSavePrereqResponse taken courses
 
-generatePrereqResponse :: [String] -> [String] -> IO Response
-generatePrereqResponse taken courses = do
+generateAndSavePrereqResponse :: [String] -> [String] -> IO Response
+generateAndSavePrereqResponse taken courses = do 
   cached <- getGraph graphHash
   case cached of
     Just cachedGraph -> return cachedGraph
@@ -50,11 +51,17 @@ generatePrereqResponse taken courses = do
       parseDynamicSvg graphHash $ decodeUtf8 bString
       storedGraph <- getGraph graphHash
       return $ fromMaybe graphNotFound storedGraph
-  where
-    -- Uniquely identify the graph in the database.
+  where    
     graphHash :: T.Text
-    graphHash = (T.pack . ("gen_" ++) . md5s . Str . show) (taken, courses)
+    graphHash = hash taken courses
     graphNotFound = error "Graph should have been generated but was not found"
+
+-- | Hash function to uniquely identify the graph layout.
+hash :: [String] -> [String] -> T.Text
+hash taken courses = hashFunction key
+  where key = (sort taken, sort courses, emptyGraph)
+        hashFunction :: (Show b) => ([String], [String], b) -> T.Text
+        hashFunction = T.pack . ("gen_" ++) . md5s . Str . show  
 
 graphToByteString :: PrintDotRepr dg n => dg n -> IO B.ByteString
 graphToByteString graph = graphvizWithHandle Dot graph Svg B.hGetContents

--- a/app/Routes.hs
+++ b/app/Routes.hs
@@ -7,12 +7,14 @@ import Response
 import Database.CourseQueries (retrieveCourse, allCourses, queryGraphs, courseInfo, deptList, getGraphJSON)
 import Database.CourseInsertion (saveGraphJSON)
 import Data.Text.Lazy (Text)
-import DynamicGraphs.WriteRunDot (findPrereqsResponse)
+import DynamicGraphs.WriteRunDot (findAndSavePrereqsResponse)
 
 routes :: String -> Text -> Text -> [ (String, ServerPart Response)]
 routes staticDir aboutContents privacyContents = [
     ("grid", gridResponse),
-    ("graph", graphResponse),
+    ("graph/generate", do method PUT
+                          findAndSavePrereqsResponse),
+    ("graph", graphResponse), 
     ("image", look "JsonLocalStorageObj" >>= graphImageResponse),
     ("timetable-image", lookText' "session" >>= \session -> look "courses" >>= exportTimetableImageResponse session),
     ("timetable-pdf", look "courses" >>= \courses -> look "JsonLocalStorageObj" >>= exportTimetablePDFResponse courses),
@@ -30,6 +32,5 @@ routes staticDir aboutContents privacyContents = [
     ("calendar", look "courses" >>= calendarResponse),
     ("get-json-data", lookText' "graphName" >>= \graphName -> liftIO $ getGraphJSON graphName),
     ("loading", lookText' "size" >>= loadingResponse),
-    ("save-json", lookBS "jsonData" >>= \jsonStr -> lookText' "nameData" >>= \nameStr -> liftIO $ saveGraphJSON jsonStr nameStr),
-    ("find-prereqs", findPrereqsResponse)
+    ("save-json", lookBS "jsonData" >>= \jsonStr -> lookText' "nameData" >>= \nameStr -> liftIO $ saveGraphJSON jsonStr nameStr)
     ]

--- a/app/Routes.hs
+++ b/app/Routes.hs
@@ -12,9 +12,9 @@ import DynamicGraphs.WriteRunDot (findAndSavePrereqsResponse)
 routes :: String -> Text -> Text -> [ (String, ServerPart Response)]
 routes staticDir aboutContents privacyContents = [
     ("grid", gridResponse),
-    ("graph/generate", do method PUT
+    ("graph", graphResponse),
+    ("graph-generate", do method PUT
                           findAndSavePrereqsResponse),
-    ("graph", graphResponse), 
     ("image", look "JsonLocalStorageObj" >>= graphImageResponse),
     ("timetable-image", lookText' "session" >>= \session -> look "courses" >>= exportTimetableImageResponse session),
     ("timetable-pdf", look "courses" >>= \courses -> look "JsonLocalStorageObj" >>= exportTimetablePDFResponse courses),


### PR DESCRIPTION
Renamed `GET find-prereqs` to `PUT graph/generate`. The old endpoint was named weirdly, and it didn't make sense to have it be a GET when it saved to the database. Invoking the new endpoint looks like:
 `PUT {url}/graph/generate?taken=[...]&courses=[...]` 
where `taken` is an array of the courses you don't want in the generated graph, and `courses` is an array of the courses you want to see the requirements for.
Ex:
 `PUT localhost:8000/graph/generate?taken=["CSC148H1']&courses=["ACT247H1"]`

Also reworked the hash function used to index generated graphs is the db. The original one only considered the `taken` and `courses` arrays. The new function also takes into account the `DotGraph` attributes.